### PR TITLE
Focus and select content of command box when selected

### DIFF
--- a/FormMain.cs
+++ b/FormMain.cs
@@ -566,6 +566,11 @@ namespace GitForce
             bool @checked = menuViewCommandLine.Checked;
             Properties.Settings.Default.ShowCommandLine = menuViewCommandLine.Checked = !@checked;
             cmdBox.Visible = !@checked;
+            if (cmdBox.Visible)
+            {
+                cmdBox.SelectAll();
+                cmdBox.Focus();
+            }
 
             // This is purely cosmetic: pushes the list pane text up to cleanly reveal the tail
             listStatus.TopIndex = listStatus.Items.Count - 1;


### PR DESCRIPTION
When using the menu item or F2 to display the command line box, you
usually want to start typing, then focus should be moved there. Also, if
you previously wrote something there, it should be selected, so you can
easily type over it.
