### PR TITLE
Enable canceling of Multiple Instance warning

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -166,7 +166,7 @@ namespace GitForce
             // Check that only one application instance is running
             bool mAcquired;
             Mutex mAppMutex = new Mutex(true, "gitforce", out mAcquired);
-            if(!mAcquired)
+            if (!mAcquired && Properties.Settings.Default.WarnMultipleInstances)
             {
                 if (MessageBox.Show("GitForce is already running.\nDo you want to open a new instance?", "Warning",
                     MessageBoxButtons.YesNo, MessageBoxIcon.Warning, MessageBoxDefaultButton.Button2) == DialogResult.No)

--- a/Properties/Settings.Designer.cs
+++ b/Properties/Settings.Designer.cs
@@ -396,5 +396,17 @@ namespace GitForce.Properties {
                 this["ShowTabsOnRightPane"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("True")]
+        public bool WarnMultipleInstances {
+            get {
+                return ((bool)(this["WarnMultipleInstances"]));
+            }
+            set {
+                this["WarnMultipleInstances"] = value;
+            }
+        }
     }
 }

--- a/Properties/Settings.settings
+++ b/Properties/Settings.settings
@@ -98,5 +98,8 @@
     <Setting Name="ShowTabsOnRightPane" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
+    <Setting Name="WarnMultipleInstances" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">True</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/Settings.Panels/ControlOptions.Designer.cs
+++ b/Settings.Panels/ControlOptions.Designer.cs
@@ -29,6 +29,7 @@
         private void InitializeComponent()
         {
             this.checkBoxTabs = new System.Windows.Forms.CheckBox();
+            this.checkBoxWarnMultipleInstances = new System.Windows.Forms.CheckBox(); 
             this.SuspendLayout();
             // 
             // checkBoxTabs
@@ -41,11 +42,22 @@
             this.checkBoxTabs.Text = "Show tabs on the right pane";
             this.checkBoxTabs.UseVisualStyleBackColor = true;
             // 
+            // checkBoxWarnMultipleInstances
+            // 
+            this.checkBoxWarnMultipleInstances.AutoSize = true;
+            this.checkBoxWarnMultipleInstances.Location = new System.Drawing.Point(3, 26);
+            this.checkBoxWarnMultipleInstances.Name = "checkBoxWarnMultipleInstances";
+            this.checkBoxWarnMultipleInstances.Size = new System.Drawing.Size(259, 17);
+            this.checkBoxWarnMultipleInstances.TabIndex = 1;
+            this.checkBoxWarnMultipleInstances.Text = "&Warn before starting additional instance of GitForce";
+            this.checkBoxWarnMultipleInstances.UseVisualStyleBackColor = true;
+            // 
             // ControlOptions
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.Controls.Add(this.checkBoxTabs);
+            this.Controls.Add(this.checkBoxWarnMultipleInstances);
             this.Name = "ControlOptions";
             this.Size = new System.Drawing.Size(300, 300);
             this.Tag = "Options";
@@ -57,6 +69,7 @@
         #endregion
 
         private System.Windows.Forms.CheckBox checkBoxTabs;
+        private System.Windows.Forms.CheckBox checkBoxWarnMultipleInstances;
 
     }
 }

--- a/Settings.Panels/ControlOptions.cs
+++ b/Settings.Panels/ControlOptions.cs
@@ -23,6 +23,7 @@ namespace GitForce.Settings.Panels
         public void Init(string[] options)
         {
             checkBoxTabs.Checked = Properties.Settings.Default.ShowTabsOnRightPane;
+            checkBoxWarnMultipleInstances.Checked = Properties.Settings.Default.WarnMultipleInstances;
 
             // Add the dirty (modified) value changed helper
             checkBoxTabs.CheckStateChanged += ControlDirtyHelper.ControlDirty;
@@ -41,6 +42,7 @@ namespace GitForce.Settings.Panels
         public void ApplyChanges()
         {
             Properties.Settings.Default.ShowTabsOnRightPane = checkBoxTabs.Checked;
+            Properties.Settings.Default.WarnMultipleInstances = checkBoxWarnMultipleInstances.Checked;
 
             if (checkBoxTabs.Tag != null)
                 App.MainForm.UpdateRightPaneTabs();

--- a/app.config
+++ b/app.config
@@ -105,6 +105,9 @@
         <setting name="ShowTabsOnRightPane" serializeAs="String">
           <value>True</value>
         </setting>
+          <setting name="WarnMultipleInstances" serializeAs="String">
+            <value>True</value>
+          </setting>
       </GitForce.Properties.Settings>
     </userSettings>
 </configuration>


### PR DESCRIPTION
Enable user to work with multiple instance without being nagged whenever
a second instance is opened.
