### PR TITLE
Fix exception when revisions filter returns no results

### DIFF
--- a/Main.Right.Panels/PanelRevlist.cs
+++ b/Main.Right.Panels/PanelRevlist.cs
@@ -101,6 +101,7 @@ namespace GitForce.Main.Right.Panels
             foreach (string s in response)
             {
                 string[] cat = s.Split('\t');
+                if (s.Length < 2) continue; // Handle empty results (single empty string) correctly
 
                 // Convert the date/time from UNIX second based to C# date structure
                 DateTime date = new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc).AddSeconds(Convert.ToDouble(cat[1])).ToLocalTime();


### PR DESCRIPTION
Scenario:
1. Show Revisions (F7)
2. Open Filter window
3. Check the Author checkbox and fill garbage in the textbox
4. Click OK
This should show an empty list, but an exception is raised.
