### PR TITLE
Reset revisions list when all checkboxes are cleared

### DIFF
--- a/FormChangelistFilter.cs
+++ b/FormChangelistFilter.cs
@@ -55,10 +55,7 @@ namespace GitForce
                 gitFilter += " --after=" + String.Format("{0:yyyy/MM/dd}", dt);                
             }
 
-            if (string.IsNullOrEmpty(gitFilter))
-                DialogResult = DialogResult.Cancel;
-            else
-                App.PrintLogMessage("Condition: " + gitFilter);
+            App.PrintLogMessage("Condition: " + gitFilter);
         }
     }
 }


### PR DESCRIPTION
Scenario:
1. Show revisions (F7)
2. Set filter to narrow the list
3. Open the filter window and clear all checkboxes
4. Click OK

This should display all results, but in fact nothing happens.
I know there is a Clear Filter button, but the user expects, when clearing all checkboxes, to have the same effect of showing all revisions.
