### PR TITLE
Store Commit Collapsed State

### DIFF
--- a/ClassCommit.cs
+++ b/ClassCommit.cs
@@ -59,6 +59,11 @@ namespace GitForce
         public bool IsDefault;
 
         /// <summary>
+        /// Is this commint node collapsed in the commits tree
+        /// </summary>
+        public bool IsCollapsed;
+
+        /// <summary>
         /// Create a commit with the given description
         /// </summary>
         public ClassCommit(string desc)

--- a/ClassView.cs
+++ b/ClassView.cs
@@ -1,7 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Drawing;
 using System.IO;
-using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Windows.Forms;
@@ -18,7 +18,8 @@ namespace GitForce
         /// <summary>
         /// Enumeration of icons for files at different stage
         /// </summary>
-        public enum Img {
+        public enum Img
+        {
             FileUnmodified,
             FileModified,
             FileAdded,
@@ -97,7 +98,7 @@ namespace GitForce
             foreach (TreeNode tn in nodes)
             {
                 if (tn.Tag is ClassCommit)
-                    tn.ImageIndex = (int) Img.Changelist;
+                    tn.ImageIndex = (int)Img.Changelist;
                 else
                 {
                     string name = isIndex ? tn.Text : tn.Tag.ToString();
@@ -168,10 +169,11 @@ namespace GitForce
             else
             {
                 var vSort = from s in list
-                    orderby Path.GetExtension(s), s ascending
-                    select s;
+                            orderby Path.GetExtension(s), s ascending
+                            select s;
                 list = vSort.ToList();
             }
+
             // Build a list view);
             foreach (string s in list)
             {
@@ -198,6 +200,8 @@ namespace GitForce
             {
                 TreeNode commitNode = new TreeNode(c.Description);
                 commitNode.Tag = c;
+
+                if (c.IsCollapsed) commitNode.Collapse();
 
                 foreach (var f in c.Files)
                 {

--- a/Main.Right.Panels/PanelCommits.Designer.cs
+++ b/Main.Right.Panels/PanelCommits.Designer.cs
@@ -90,6 +90,8 @@
             this.treeCommits.TabIndex = 1;
             this.treeCommits.BeforeLabelEdit += new System.Windows.Forms.NodeLabelEditEventHandler(this.TreeCommitsBeforeLabelEdit);
             this.treeCommits.AfterLabelEdit += new System.Windows.Forms.NodeLabelEditEventHandler(this.TreeCommitsAfterLabelEdit);
+            this.treeCommits.AfterCollapse += new System.Windows.Forms.TreeViewEventHandler(this.TreeCommitsAfterCollapse);
+            this.treeCommits.AfterExpand += new System.Windows.Forms.TreeViewEventHandler(this.TreeCommitsAfterExpand);
             this.treeCommits.AfterSelect += new System.Windows.Forms.TreeViewEventHandler(this.TreeCommitsAfterSelect);
             this.treeCommits.PreviewKeyDown += new System.Windows.Forms.PreviewKeyDownEventHandler(this.TreeCommitsPreviewKeyDown);
             this.treeCommits.MouseUp += new System.Windows.Forms.MouseEventHandler(this.TreeCommitsMouseUp);

--- a/Main.Right.Panels/PanelCommits.cs
+++ b/Main.Right.Panels/PanelCommits.cs
@@ -702,5 +702,23 @@ namespace GitForce.Main.Right.Panels
                 treeCommits.SelectedNode.BeginEdit();
             }
         }
+
+        private static void UpdateCommitCollapsed(TreeViewEventArgs e)
+        {
+            if (e.Node == null) return;
+            var commit = e.Node.Tag as ClassCommit;
+            if (commit == null) return;
+            commit.IsCollapsed = !e.Node.IsExpanded;
+        }
+
+        private void TreeCommitsAfterCollapse(object sender, TreeViewEventArgs e)
+        {
+            UpdateCommitCollapsed(e);
+        }
+
+        private void TreeCommitsAfterExpand(object sender, TreeViewEventArgs e)
+        {
+            UpdateCommitCollapsed(e);
+        }
     }
 }


### PR DESCRIPTION
This commit stores the collapse/expand state of each commit in the commits tree, so not all commits are expanded when refreshing or restarting. Very useful when working with numerous commits.
