### PR TITLE
Make Delete shortcut work by updating Changelist menu on selection

### DIFF
--- a/FormMain.cs
+++ b/FormMain.cs
@@ -686,6 +686,11 @@ namespace GitForce
         /// </summary>
         private void MenuMainChangelistDropDownOpening(object sender, EventArgs e)
         {
+            BuildChangelistMenu();
+        }
+
+        public void BuildChangelistMenu()
+        {
             // Add the menu items from the commit pane followed menu items from the revisions pane
             menuMainChangelist.DropDownItems.Clear();
             var selectedNode = PanelCommits.SelectedNode;

--- a/Main.Right.Panels/PanelCommits.cs
+++ b/Main.Right.Panels/PanelCommits.cs
@@ -700,6 +700,7 @@ namespace GitForce.Main.Right.Panels
             if (_lastSelectedNode == treeCommits.SelectedNode) return;
             _lastSelectedNode = treeCommits.SelectedNode;
             if ((MouseButtons & MouseButtons.Left) == MouseButtons.Left) _duringSelect = true;
+            App.MainForm.BuildChangelistMenu();
         }
 
         private void TreeCommitsPreviewKeyDown(object sender, PreviewKeyDownEventArgs e)


### PR DESCRIPTION
In my previous task, Delete shortcut only worked after the first time the Changelist menu was opened and popuplated. This fixes it by updating the menu on every selection in the Commits tree (similar to how the File menu is updated).
